### PR TITLE
Adds RequestActionObjectResolver and InternalDataSiloObjectResolver

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -40,6 +40,7 @@
     "camelcase",
     "codomain",
     "compat",
+    "datapoint",
     "depcheck",
     "doctoc",
     "eqeqeq",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/privacy-types",
   "description": "Core enums and types that can be useful when interacting with Transcend's public APIs.",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "homepage": "https://github.com/transcend-io/privacy-types",
   "repository": {
     "type": "git",

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -52,6 +52,23 @@ export type RequestActionObjectResolver =
   typeof RequestActionObjectResolver[keyof typeof RequestActionObjectResolver];
 
 /**
+ * The privacy actions that can be set at the object level for a
+ * data silo configured as webhook or cron integration.
+ *
+ * Privacy actions are specified globally and logic is left to the
+ * webhook service to implement. The individual objects can still be
+ * labeled for whether they should be included in data access requests.
+ */
+export const InternalDataSiloObjectResolver = makeEnum({
+  /** Data Download request */
+  Access: 'ACCESS',
+});
+
+/** Type override */
+export type InternalDataSiloObjectResolver =
+  typeof InternalDataSiloObjectResolver[keyof typeof InternalDataSiloObjectResolver];
+
+/**
  * The types of requests that Data Subject can make
  */
 export const RequestAction = makeEnum({

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -19,6 +19,39 @@ export type RequestActionOptOut =
   typeof RequestActionOptOut[keyof typeof RequestActionOptOut];
 
 /**
+ * An request action resolve types that can be run at the object level
+ */
+export const RequestActionObjectResolver = makeEnum({
+  /** Data Download request */
+  Access: 'ACCESS',
+  /** Erase the file completely */
+  Erasure: 'ERASURE',
+  /** Run an account deletion instead of a fully compliant deletion */
+  AccountDeletion: 'ACCOUNT_DELETION',
+  /** Opt out of automated decision making */
+  AutomatedDecisionMakingOptOut: 'AUTOMATED_DECISION_MAKING_OPT_OUT',
+  /** A contact opt out request */
+  ContactOptOut: 'CONTACT_OPT_OUT',
+  /** Opt-out of the sale of personal data */
+  SaleOptOut: 'SALE_OPT_OUT',
+  /** A tracking opt out request */
+  TrackingOptOut: 'TRACKING_OPT_OUT',
+  /** Make an update to an inaccurate record */
+  Rectification: 'RECTIFICATION',
+  /** A restriction of processing request */
+  Restriction: 'RESTRICTION',
+  /**
+   * TODO: https://transcend.height.app/T-4327 - add in the ability to choose ERASURE vs REDACT
+   * --  Redact the personal data from the file, without deleting it entirely
+   */
+  // Redact: 'REDACT',
+});
+
+/** Type override */
+export type RequestActionObjectResolver =
+  typeof RequestActionObjectResolver[keyof typeof RequestActionObjectResolver];
+
+/**
  * The types of requests that Data Subject can make
  */
 export const RequestAction = makeEnum({


### PR DESCRIPTION
Adds enum definitions that can be shared between the server/cron integrations and the public schema-sync API cli. These enums determine the set of actions that can be defined at the silo and object levels.