### PR TITLE
Adds more advertising ids to identifier type

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -47,6 +47,7 @@
     "depcheck",
     "doctoc",
     "eqeqeq",
+    "gaid",
     "gpadvid",
     "idfa",
     "linebreak",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -37,6 +37,8 @@
     "source.fixAll": true
   },
   "cSpell.words": [
+    "aaid",
+    "Adid",
     "camelcase",
     "chargebee",
     "codomain",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -47,6 +47,8 @@
     "depcheck",
     "doctoc",
     "eqeqeq",
+    "filestack",
+    "filestackHandle",
     "gaid",
     "gpadvid",
     "idfa",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/privacy-types",
   "description": "Core enums and types that can be useful when interacting with Transcend's public APIs.",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "homepage": "https://github.com/transcend-io/privacy-types",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/privacy-types",
   "description": "Core enums and types that can be useful when interacting with Transcend's public APIs.",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "homepage": "https://github.com/transcend-io/privacy-types",
   "repository": {
     "type": "git",

--- a/src/identifier.ts
+++ b/src/identifier.ts
@@ -40,6 +40,8 @@ export const IdentifierType = makeEnum({
   MicrosoftAdvertisingId: 'microsoftAdvertisingId',
   /** Amazon fire Advertising Id */
   AmazonFireAdvertisingId: 'amazonFireAdvertisingId',
+  /** The handle for the filestack file  */
+  FilestackHandle: 'filestackHandle',
   /** An ID for a stripe user */
   StripeId: 'stripeId',
   /** An ID for a chargebee user */

--- a/src/identifier.ts
+++ b/src/identifier.ts
@@ -31,6 +31,12 @@ export const IdentifierType = makeEnum({
   Gpadvid: 'gpadvid',
   /** Apple ios mobile identifier */
   Idfa: 'idfa',
+  /** Google Android mobile identifier */
+  Adid: 'aaid',
+  /** Microsoft Advertising Id */
+  MicrosoftAdvertisingId: 'microsoftAdvertisingId',
+  /** Amazon fire Advertising Id */
+  AmazonFireAdvertisingId: 'amazonFireAdvertisingId',
   /** An ID for a stripe user */
   StripeId: 'stripeId',
   /** An ID for a chargebee user */

--- a/src/identifier.ts
+++ b/src/identifier.ts
@@ -27,12 +27,15 @@ export const IdentifierType = makeEnum({
   Custom: 'custom',
   /** A phone number */
   Phone: 'phone',
-  /** Google Android mobile identifier */
-  Gpadvid: 'gpadvid',
+  /**
+   * Google/Android mobile identifier
+   *
+   * @see https://www.singular.net/blog/google-advertising-id-gaid/
+   * AKA adid - android advertising id
+   */
+  Gaid: 'gaid',
   /** Apple ios mobile identifier */
   Idfa: 'idfa',
-  /** Google Android mobile identifier */
-  Adid: 'aaid',
   /** Microsoft Advertising Id */
   MicrosoftAdvertisingId: 'microsoftAdvertisingId',
   /** Amazon fire Advertising Id */


### PR DESCRIPTION
<img width="688" alt="Screen Shot 2022-04-08 at 9 46 45 PM" src="https://user-images.githubusercontent.com/10264973/162556795-c54e8cd4-8cd1-4256-ba60-c89baec9ffb6.png">


seeing that tools like appsflyer can get this specific

also updates google id acronym based on this article: https://www.singular.net/blog/google-advertising-id-gaid/