### PR TITLE
Fix all enum casing

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/privacy-types",
   "description": "Core enums and types that can be useful when interacting with Transcend's public APIs.",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "homepage": "https://github.com/transcend-io/privacy-types",
   "repository": {
     "type": "git",

--- a/src/subcategories/financial.ts
+++ b/src/subcategories/financial.ts
@@ -1,11 +1,11 @@
 import { makeEnum } from '@transcend-io/type-utils';
 
 export const FinancialSubCategory = makeEnum({
-  /** Credit Card Number */
-  CreditCardNumber: 'creditCardNumber',
   // TODO: https://transcend.height.app/T-14003 - add more financial subcategories (routing number, etc.)
   /** Fallback subcategory */
   Financial: 'FINANCIAL',
+  /** Credit Card Number */
+  CreditCardNumber: 'CREDIT_CARD_NUMBER',
 });
 
 /**


### PR DESCRIPTION
## Related Issues

- Our enums should using CONSTANT_CASING unless there is a good reason to not.

## Security Implications

_[none]_

## System Availability

_[none]_
