### PR TITLE
Add Roku advertising ID identifier type

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -61,6 +61,7 @@
     "pnpify",
     "preact",
     "Requirize",
+    "rida",
     "thlorenz",
     "tsbuildinfo",
     "yarnpkg"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/privacy-types",
   "description": "Core enums and types that can be useful when interacting with Transcend's public APIs.",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "homepage": "https://github.com/transcend-io/privacy-types",
   "repository": {
     "type": "git",

--- a/src/identifier.ts
+++ b/src/identifier.ts
@@ -48,8 +48,12 @@ export const IdentifierType = makeEnum({
   MicrosoftAdvertisingId: 'microsoftAdvertisingId',
   /** Amazon fire Advertising Id */
   AmazonFireAdvertisingId: 'amazonFireAdvertisingId',
-  /** Roku Advertising Id */
-  RokuAdvertisingId: 'rokuAdvertisingId',
+  /**
+   * Roku Advertising Id
+   *
+   * @see https://developer.roku.com/docs/developer-program/advertising/integrating-roku-advertising-framework.md
+   */
+  Rida: 'rida',
   /** The handle for the filestack file  */
   FilestackHandle: 'filestackHandle',
   /** An ID for a stripe user */

--- a/src/identifier.ts
+++ b/src/identifier.ts
@@ -48,6 +48,8 @@ export const IdentifierType = makeEnum({
   MicrosoftAdvertisingId: 'microsoftAdvertisingId',
   /** Amazon fire Advertising Id */
   AmazonFireAdvertisingId: 'amazonFireAdvertisingId',
+  /** Roku Advertising Id */
+  RokuAdvertisingId: 'rokuAdvertisingId',
   /** The handle for the filestack file  */
   FilestackHandle: 'filestackHandle',
   /** An ID for a stripe user */


### PR DESCRIPTION
[Roku Advertising ID](https://developer.roku.com/docs/developer-program/advertising/integrating-roku-advertising-framework.md): The **Roku ID for Advertising** is a device identifier available to Roku publishers for development and marketing purposes.

## Related Issues

- Found an identifier listed in [mParticle's DSR API docs](https://docs.mparticle.com/developers/dsr-api/v3/#supported-identity-types) that may be useful to add to our list of advertising IDs.
