### PR TITLE
Remove deprecated default subcategories

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/privacy-types",
   "description": "Core enums and types that can be useful when interacting with Transcend's public APIs.",
-  "version": "3.5.1",
+  "version": "4.0.0",
   "homepage": "https://github.com/transcend-io/privacy-types",
   "repository": {
     "type": "git",

--- a/src/subcategories/contact.ts
+++ b/src/subcategories/contact.ts
@@ -5,12 +5,6 @@ export const ContactSubCategory = makeEnum({
   Email: 'EMAIL',
   /** A phone number */
   Phone: 'PHONE',
-  /**
-   * How to refer to someone (e.g. Sir/Madam/Mr/Ms)
-   *
-   * @deprecated
-   */
-  Title: 'TITLE',
   /** Fallback subcategory */
   Contact: 'CONTACT',
 });

--- a/src/subcategories/financial.ts
+++ b/src/subcategories/financial.ts
@@ -12,12 +12,6 @@ export const FinancialSubCategory = makeEnum({
   Tax: 'TAX',
   /** Routing number */
   RoutingNumber: 'ROUTING_NUMBER',
-  /**
-   * Debit Card Number
-   *
-   * @deprecated
-   */
-  DebitCardNumber: 'DEBIT_CARD_NUMBER',
   /** Fallback subcategory */
   Financial: 'FINANCIAL',
 });

--- a/src/subcategories/health.ts
+++ b/src/subcategories/health.ts
@@ -2,24 +2,6 @@ import { makeEnum } from '@transcend-io/type-utils';
 
 /** Information about an individual's health */
 export const HealthSubCategory = makeEnum({
-  /**
-   * Information relating to an individual's health insurance
-   *
-   * @deprecated
-   */
-  Insurance: 'INSURANCE',
-  /**
-   * Biometric data from an individual like heart rate or fitness level information
-   *
-   * @deprecated
-   */
-  Biometrics: 'BIOMETRICS',
-  /**
-   * An individual's genetic data
-   *
-   * @deprecated
-   */
-  Genetics: 'GENETICS',
   /** Fallback subcategory */
   Health: 'HEALTH',
 });

--- a/src/subcategories/location.ts
+++ b/src/subcategories/location.ts
@@ -1,24 +1,6 @@
 import { makeEnum } from '@transcend-io/type-utils';
 
 export const LocationSubCategory = makeEnum({
-  /**
-   * An address where an individual is located
-   *
-   * @deprecated
-   */
-  PhysicalAddress: 'PHYSICAL_ADDRESS',
-  /**
-   * Exact coordinates for an individual's location
-   *
-   * @deprecated
-   */
-  PreciseGeolocation: 'PRECISE_GEOLOCATION',
-  /**
-   * Approximate area where an individual is located
-   *
-   * @deprecated
-   */
-  ApproximateLocation: 'APPROXIMATE_LOCATION',
   /** Fallback subcategory */
   Location: 'LOCATION',
 });


### PR DESCRIPTION
## Related Issues

- Closes https://transcend.height.app/T-15814

## Security Implications

_[none]_

## System Availability

- We removed some values from `DefaultDataSubCategoryType` so care should be taken to not reference those values anymore when upgrading the privacy-types major version.
