### PR TITLE
Export iso country + subdivision objects

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v3.1.1
         with:
           node-version: '14.17.3'
       - run: npm install -g "yarn@1.22.5"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          node-version: '14.17.3'
       - name: Build the typescript code
         run: yarn build
       - uses: actions/upload-artifact@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,14 @@ jobs:
       - uses: actions/checkout@v2
         with:
           node-version: '14.17.3'
+      - run: npm install -g "yarn@1.22.5"
+        shell: bash
+      - uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 6
+          max_attempts: 3
+          retry_on: error
+          command: yarn install --immutable
       - name: Build the typescript code
         run: yarn build
       - uses: actions/upload-artifact@main

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/privacy-types",
   "description": "Core enums and types that can be useful when interacting with Transcend's public APIs.",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "homepage": "https://github.com/transcend-io/privacy-types",
   "repository": {
     "type": "git",

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,3 +7,4 @@ export * from './purposeSubCategories';
 export * from './promptAVendor';
 export * from './scopes';
 export * from './isoRegion';
+export * from './isoConstants';

--- a/src/isoConstants/index.ts
+++ b/src/isoConstants/index.ts
@@ -1,0 +1,2 @@
+export * from './iso3166-1';
+export * from './iso3166-2';


### PR DESCRIPTION
Exports ISO_31662 and ISO_31661, so ISO codes can be converted to human readable countries and country subdivisions. 

## Related Issues

- Closes https://transcend.height.app/T-16860

## Security Implications

_[none]_

## System Availability

_[none]_
