### PR TITLE
add Amazon S3 to supported DatabaseDriver

### DIFF
--- a/src/database.ts
+++ b/src/database.ts
@@ -13,6 +13,7 @@ export const DatabaseIntegration = makeEnum({
   maria: 'maria',
   mongodb: 'mongodb',
   amazondynamodb: 'amazondynamodb',
+  amazons3: 'amazons3',
 });
 
 /**
@@ -40,6 +41,7 @@ export const DatabaseDriver = makeEnum({
   ...SQLDriverWithDataMapping,
   [DatabaseIntegration.mongodb]: 'MongoDB',
   [DatabaseIntegration.amazondynamodb]: 'AmazonDynamoDB',
+  [DatabaseIntegration.amazons3]: 'AmazonS3',
 });
 
 /** Overrides type */


### PR DESCRIPTION
## Related Issues

- https://transcend.height.app/T-15193

## Description

- we need to define an S3 DatabaseDriver so we can turn the integration into a database integration and support content classification.