### PR TITLE
View requests scope depends on view email templates

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/privacy-types",
   "description": "Core enums and types that can be useful when interacting with Transcend's public APIs.",
-  "version": "4.21.0",
+  "version": "4.22.0",
   "homepage": "https://github.com/transcend-io/privacy-types",
   "repository": {
     "type": "git",

--- a/src/scopes.ts
+++ b/src/scopes.ts
@@ -399,6 +399,7 @@ const SCOPES_WITHOUT_VIEW_ONLY: {
     dependencies: [
       ScopeName.ViewGlobalAttributes,
       ScopeName.ViewDataSubjectRequestSettings,
+      ScopeName.ViewEmailTemplates,
     ],
     description:
       'View the stream of incoming requests, and any details submit through the form or later enriched.',
@@ -410,6 +411,7 @@ const SCOPES_WITHOUT_VIEW_ONLY: {
     dependencies: [
       ScopeName.ViewGlobalAttributes,
       ScopeName.ViewDataSubjectRequestSettings,
+      ScopeName.ViewEmailTemplates,
     ],
     description:
       // eslint-disable-next-line max-len


### PR DESCRIPTION
## Related Issues

- _[none]_

## Security Implications

- View Requests & View Assigned Requests Scopes now depend on View Email Templates.