### PR TITLE
New scope to manage consent manager developer settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/privacy-types",
   "description": "Core enums and types that can be useful when interacting with Transcend's public APIs.",
-  "version": "4.24.0",
+  "version": "4.25.0",
   "homepage": "https://github.com/transcend-io/privacy-types",
   "repository": {
     "type": "git",

--- a/src/scopes.ts
+++ b/src/scopes.ts
@@ -14,6 +14,7 @@ export enum ScopeName {
   ManageConsentManager = 'manageConsentManager',
   ViewConsentManager = 'viewConsentManager',
   ManageConsentManagerDisplaySettings = 'manageConsentManagerDisplaySettings',
+  ManageConsentManagerDeveloperSettings = 'manageConsentManagerDeveloperSettings',
   ManageDataFlow = 'manageDataFlow',
   DeployConsentManager = 'deployConsentManager',
   ViewCustomerDataDataMapping = 'viewCustomerDataDataMapping',
@@ -524,12 +525,22 @@ const SCOPES_WITHOUT_VIEW_ONLY: {
       ScopeName.ViewConsentManager,
       ScopeName.ManageDataFlow,
       ScopeName.ManageConsentManagerDisplaySettings,
+      ScopeName.ManageConsentManagerDeveloperSettings,
       ScopeName.DeployConsentManager,
       ScopeName.ViewDataFlow,
     ],
     description:
       'Manage & deploy the consent manager changes to your websites.',
     title: 'Manage Consent Manager',
+    type: ScopeType.Modify,
+    products: [TranscendProduct.ConsentManager],
+  },
+  [ScopeName.ManageConsentManagerDeveloperSettings]: {
+    dependencies: [ScopeName.ViewConsentManager],
+    description:
+      'Manage the developer settings for the Consent Manager. ' +
+      'This does not allow for clicking the "Set Changes Live" button.',
+    title: 'Manage Consent Manager Developer Settings',
     type: ScopeType.Modify,
     products: [TranscendProduct.ConsentManager],
   },


### PR DESCRIPTION
## Related Issues

- links https://transcend.height.app/T-23575

This will allow for a more specific scope to modify consent developer settings without the ability to publish changes.