### PR TITLE
Add OTHER subcategory

### DIFF
--- a/src/subcategories/index.ts
+++ b/src/subcategories/index.ts
@@ -8,6 +8,7 @@ import { FinancialSubCategory } from './financial';
 import { HealthSubCategory } from './health';
 import { IdSubCategory } from './id';
 import { LocationSubCategory } from './location';
+import { OtherDataSubCategory } from './other';
 import { OnlineActivitySubCategory } from './onlineActivity';
 import { SocialMediaSubCategory } from './socialMedia';
 import { SurveySubCategory } from './survey';
@@ -30,6 +31,7 @@ export const DefaultDataSubCategoryType = makeEnum({
   ...TrackingSubCategory,
   ...UserProfileSubCategory,
   ...NotPersonalDataSubCategory,
+  ...OtherDataSubCategory,
 });
 
 /**

--- a/src/subcategories/other.ts
+++ b/src/subcategories/other.ts
@@ -1,0 +1,13 @@
+import { makeEnum } from '@transcend-io/type-utils';
+
+/** Information that does not belong to an individual */
+export const OtherDataSubCategory = makeEnum({
+  /** Fallback subcategory */
+  Other: 'OTHER',
+});
+
+/**
+ * Overload with type of integration
+ */
+export type OtherDataSubCategory =
+  typeof OtherDataSubCategory[keyof typeof OtherDataSubCategory];


### PR DESCRIPTION
So it seems that the difference between the classifier version 12 and 13 is that the classifier 13 is returning a type that the codec is not able to decode. We are returning a type OTHER. For example, on the list of guesses is returning this:

```
{
  type: 'OTHER',
  confidence: 0.083034222365714,
  classifierVersion: 13,
  confidenceLabel: 'LOW'
}
```

The problem is that we don't have OTHER as a type and so it fails with this message: `Failed to decode codec: `.This PR adds the OTHER type so that when we update the classifier to version 13, it indeeds work as intended!

## Related Issues

- Links https://transcend.height.app/T-24741

## Security Implications

_[none]_

## System Availability

_[none]_
