### PR TITLE
Remove second Greece from IsoCountryCode

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/privacy-types",
   "description": "Core enums and types that can be useful when interacting with Transcend's public APIs.",
-  "version": "4.38.3",
+  "version": "4.38.4",
   "homepage": "https://github.com/transcend-io/privacy-types",
   "repository": {
     "type": "git",

--- a/src/isoConstants/iso3166-1.ts
+++ b/src/isoConstants/iso3166-1.ts
@@ -92,7 +92,6 @@ export const COUNTRY_LOOKUP = {
   GH: 'Ghana',
   GI: 'Gibraltar',
   GR: 'Greece',
-  EL: 'Greece',
   GL: 'Greenland',
   GD: 'Grenada',
   GP: 'Guadeloupe',

--- a/src/macroregion.ts
+++ b/src/macroregion.ts
@@ -15,7 +15,6 @@ export type MacroRegion = typeof MacroRegion[keyof typeof MacroRegion];
 export const DEFAULT_MACROREGIONS_MAP = {
   [MacroRegion.EU]: [
     IsoCountryCode.BE, // Belgium
-    IsoCountryCode.EL, // Greece
     IsoCountryCode.GR, // Greece
     IsoCountryCode.LT, // Lithuania
     IsoCountryCode.PT, // Portugal


### PR DESCRIPTION
Removes `EL` as an IsoCountryCode for Greece.

## Related Issues

- Closes https://transcend.height.app/T-27170
- Links https://transcend.height.app/T-27139

## Security Implications

_[none]_

## System Availability

_[none]_
