### PR TITLE
add new AI Governance Proxy product and scopes

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/privacy-types",
   "description": "Core enums and types that can be useful when interacting with Transcend's public APIs.",
-  "version": "4.38.4",
+  "version": "4.39.0",
   "homepage": "https://github.com/transcend-io/privacy-types",
   "repository": {
     "type": "git",

--- a/src/scopes.ts
+++ b/src/scopes.ts
@@ -656,7 +656,7 @@ const SCOPES_WITHOUT_VIEW_ONLY: {
   [ScopeName.AuthenticateAIGovernanceProxyRequest]: {
     dependencies: [],
     description: 'Ability to send requests to the AI Governancy Proxy. Typically granted to the API Keys used to authenticate requests to the service.',
-    title: 'Authenticate AI Governance Proxy Requests',
+    title: 'Authenticate AI Governance Proxy',
     type: ScopeType.Modify,
     products: [TranscendProduct.AIGovernanceProxy]
 },

--- a/src/scopes.ts
+++ b/src/scopes.ts
@@ -68,6 +68,7 @@ export enum ScopeName {
   ViewAuditEvents = 'viewAuditEvents',
   ManageActionItemCollections = 'manageActionItemCollections',
   ViewManagedConsentDatabaseAdminApi = 'viewManagedConsentDatabaseAdminApi',
+  AuthenticateAIGovernanceProxyRequest = 'authenticateAIGovernanceProxyRequest'
 }
 
 /**
@@ -98,6 +99,8 @@ export enum TranscendProduct {
   Assessments = 'ASSESSMENTS',
   /** Sombra. */
   Sombra = 'SOMBRA',
+  /** AI Governance Proxy */
+  AIGovernanceProxy = 'AI_GOVERNANCE_PROXY'
 }
 
 /**
@@ -650,6 +653,13 @@ const SCOPES_WITHOUT_VIEW_ONLY: {
     type: ScopeType.View,
     products: [TranscendProduct.ConsentManager],
   },
+  [ScopeName.AuthenticateAIGovernanceProxyRequest]: {
+    dependencies: [],
+    description: 'Ability to send requests to the AI Governancy Proxy. Typically granted to the API Keys used to authenticate requests to the service.',
+    title: 'Authenticate AI Governance Proxy Requests',
+    type: ScopeType.Modify,
+    products: [TranscendProduct.AIGovernanceProxy]
+},
 };
 
 export const TRANSCEND_SCOPES: {


### PR DESCRIPTION
## Related Issues

- closes https://transcend.height.app/T-27330

- for now, I am using a generic name for the product + scopes just so I can finish working on adding new endpoints to the Transcend BE. Once we decide on a final name for the product we can update these scopes accordingly.
