### PR TITLE
Add action item resource type

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/privacy-types",
   "description": "Core enums and types that can be useful when interacting with Transcend's public APIs.",
-  "version": "4.40.0",
+  "version": "4.41.0",
   "homepage": "https://github.com/transcend-io/privacy-types",
   "repository": {
     "type": "git",

--- a/src/attribute.ts
+++ b/src/attribute.ts
@@ -2,6 +2,8 @@
  * Resources within the Transcend dashboard that support the attributes feature
  */
 export enum AttributeSupportedResourceType {
+  /** Action items table */
+  ActionItem = 'actionItem',
   /** Data silos table */
   DataSilo = 'dataSilo',
   /** Subdatapoints table (shows up under Data Inventory > Data Points tab) */


### PR DESCRIPTION
Add `ActionItem` to `AttributeSupportedResourceType` enum. Required for adding attribute support to action items.