### PR TITLE
Revert "Add new prompt/assessment attributes types"

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/privacy-types",
   "description": "Core enums and types that can be useful when interacting with Transcend's public APIs.",
-  "version": "4.48.0",
+  "version": "4.49.0",
   "homepage": "https://github.com/transcend-io/privacy-types",
   "repository": {
     "type": "git",

--- a/src/attribute.ts
+++ b/src/attribute.ts
@@ -22,18 +22,6 @@ export enum AttributeSupportedResourceType {
   DataSubCategory = 'dataSubCategory',
   /** Processing purpose table */
   ProcessingPurposeSubCategory = 'processingPurposeSubCategory',
-  /** Assessment table */
-  Assessment = 'assessment',
-  /** AssessmentTemplate table */
-  AssessmentTemplate = 'assessmentTemplate',
-  /** Prompt table */
-  Prompt = 'prompt',
-  /** PromptGroup table */
-  PromptGroup = 'promptGroup',
-  /** PromptRun table */
-  PromptRun = 'promptRun',
-  /** PromptTemplate table */
-  PromptTemplate = 'promptTemplate',
 }
 
 /**


### PR DESCRIPTION
Reverts transcend-io/privacy-types#120

Will need to put these back later, but it is blocking updating this package in the monorepo to have these in there until I have time to update the monorepo to support these types.