### PR TITLE
Add draft status to assessment form

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/privacy-types",
   "description": "Core enums and types that can be useful when interacting with Transcend's public APIs.",
-  "version": "4.63.1",
+  "version": "4.63.2",
   "homepage": "https://github.com/transcend-io/privacy-types",
   "repository": {
     "type": "git",

--- a/src/assessmentForm.ts
+++ b/src/assessmentForm.ts
@@ -1,5 +1,7 @@
 /** AssessmentForm status types */
 export enum AssessmentFormStatus {
+  /** The form has been created but has not been shared with assignees */
+  Draft = 'DRAFT',
   /** The form has been created from a template and shared to be filled out */
   Shared = 'SHARED',
   /** The form is in process of being answered */


### PR DESCRIPTION
Adds a "Draft" status to Assessment Forms so that users can edit assessment metadata and assign individual sections, etc. before sharing these with assignees.