### PR TITLE
Add identifier type for Plaid integration.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/privacy-types",
   "description": "Core enums and types that can be useful when interacting with Transcend's public APIs.",
-  "version": "4.69.0",
+  "version": "4.70.0",
   "homepage": "https://github.com/transcend-io/privacy-types",
   "repository": {
     "type": "git",

--- a/src/identifier.ts
+++ b/src/identifier.ts
@@ -72,6 +72,8 @@ export const IdentifierType = makeEnum({
   PersonaReferenceId: 'personaReferenceId',
   /** An ID for a Stream user */
   StreamUserId: 'streamUserId',
+  /** A token used to make API calls on behalf of a Plaid account. */
+  plaidProcessorToken: 'streamUserId',
 });
 
 /**

--- a/src/identifier.ts
+++ b/src/identifier.ts
@@ -73,7 +73,7 @@ export const IdentifierType = makeEnum({
   /** An ID for a Stream user */
   StreamUserId: 'streamUserId',
   /** A token used to make API calls on behalf of a Plaid account. */
-  plaidProcessorToken: 'streamUserId',
+  PlaidProcessorToken: 'plaidProcessorToken',
 });
 
 /**


### PR DESCRIPTION
## Related Issues

Plaid uses a data processor token to identify a single account.

Links https://transcend.height.app/T-4577
