### PR TITLE
Add identifier type for Onfido integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/privacy-types",
   "description": "Core enums and types that can be useful when interacting with Transcend's public APIs.",
-  "version": "4.72.0",
+  "version": "4.73.0",
   "homepage": "https://github.com/transcend-io/privacy-types",
   "repository": {
     "type": "git",

--- a/src/identifier.ts
+++ b/src/identifier.ts
@@ -74,6 +74,8 @@ export const IdentifierType = makeEnum({
   StreamUserId: 'streamUserId',
   /** A token used to make API calls on behalf of a Plaid account. */
   PlaidProcessorToken: 'plaidProcessorToken',
+  /** An ID for an applicant on Onfido */
+  OnfidoApplicantId: 'onfidoApplicantId',
 });
 
 /**


### PR DESCRIPTION
## Related Issues

Onfido uses an applicant ID for their Applicant endpoints.

Links https://transcend.height.app/T-13411

