### PR TITLE
Action item enums and scope

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/privacy-types",
   "description": "Core enums and types that can be useful when interacting with Transcend's public APIs.",
-  "version": "4.73.0",
+  "version": "4.74.0",
   "homepage": "https://github.com/transcend-io/privacy-types",
   "repository": {
     "type": "git",

--- a/src/actionItems.ts
+++ b/src/actionItems.ts
@@ -1,0 +1,202 @@
+/**
+ * The type of actionItem a person will be notified to fulfill
+ */
+export enum ActionItemCode {
+  /**
+   * - The action is not connected to any data silos or data points
+   */
+  ActionMissingSilos = 'ACTION_MISSING_SILOS',
+  /**
+   * API Keys that are too old (expired)
+   */
+  ApiKeyStale = 'API_KEY_STALE',
+  /**
+   * An assessment has been assigned for completion
+   */
+  AssessmentAssigned = 'ASSESSMENT_ASSIGNED',
+  /**
+   * An assessment needs review
+   */
+  AssessmentNeedsReview = 'ASSESSMENT_NEEDS_REVIEW',
+  /**
+   * An assessment has been assigned for completion
+   */
+  AssessmentFormAssigned = 'ASSESSMENT_FORM_ASSIGNED',
+  /**
+   * An assessment needs review
+   */
+  AssessmentFormNeedsReview = 'ASSESSMENT_FORM_NEEDS_REVIEW',
+  /**
+   * An assessment has changes requested
+   */
+  AssessmentChangesRequested = 'ASSESSMENT_CHANGES_REQUESTED',
+  /**
+   * An assessment has been rejected
+   */
+  AssessmentRejected = 'ASSESSMENT_REJECTED',
+  /**
+   * Someone marked a request as requiring manual review
+   */
+  RequestDataSiloMarkedActionable = 'REQUEST_DATA_SILO_MARKED_ACTIONABLE',
+  /**
+   * There are files for a data silo in a request that require manual review
+   */
+  RequestDataSiloFilesNeedReview = 'REQUEST_DATA_SILO_FILES_NEED_REVIEW',
+  /**
+   * - Unread emails with the data subject
+   */
+  CommunicationUnread = 'COMMUNICATION_UNREAD',
+  /**
+   * - Unread emails with a vendor
+   */
+  DataSiloCommunicationUnread = 'DATA_SILO_COMMUNICATION_UNREAD',
+  /**
+   * - The description is the empty string
+   * - There is no data collection
+   */
+  DataPoint = 'DATA_POINT',
+  /**
+   * - Data point has missing fields
+   */
+  DataPointMissingFields = 'DATA_POINT_MISSING_FIELDS',
+  /**
+   * - Data Silos not are EXPIRED, PERMISSIONS_UPDATED or misconfigured and are not assigned yet
+   */
+  DataSiloNeedsReconnect = 'DATA_SILO_NEEDS_RECONNECT',
+  /**
+   * - Data Silos not are EXPIRED, PERMISSIONS_UPDATED or misconfigured and are assigned
+   */
+  DataSiloNeedsReconnectAssigned = 'DATA_SILO_NEEDS_RECONNECT_ASSIGNED',
+  /**
+   * - Data Silos that are not yet brought online and launched into production and are not assigned yet
+   */
+  DataSiloNotConfigured = 'DATA_SILO_NOT_CONFIGURED',
+  /**
+   * - Data Silos that are not yet brought online and launched into production and are assigned
+   */
+  DataSiloNotConfiguredAssigned = 'DATA_SILO_NOT_CONFIGURED_ASSIGNED',
+  /**
+   * - Data Silos that are live and have no configured identifiers are invalid
+   */
+  DataSiloMissingIdentifiers = 'DATA_SILO_MISSING_IDENTIFIERS',
+  /**
+   * - Lookup processes have errored out and are no longer indexing
+   */
+  LookupProcessesWithErrors = 'LOOKUP_PROCESSES_WITH_ERRORS',
+  /**
+   * Manual entry is required for prompt a person data silo
+   * or a file was marked as requiring action item.
+   */
+  DataSilosNeedingManualEntry = 'DATA_SILOS_NEEDING_MANUAL_ENTRY',
+  /**
+   * - A profile running a specific datapoint encountered an error
+   */
+  ProfileDataPointStatus = 'PROFILE_DATA_POINT_STATUS',
+  /**
+   * - The request is nearing its expiry time
+   */
+  RequestExpiry = 'REQUEST_EXPIRY',
+  /**
+   * - A request data silo with a status that is waiting or queued
+   */
+  RequestDataSiloWaitingQueued = 'REQUEST_DATA_SILO_WAITING_QUEUED',
+  /**
+   * - A request data silo that has thrown an error
+   */
+  RequestDataSiloError = 'REQUEST_DATA_SILO_ERROR',
+  /**
+   * - non person enricher that's waiting or queued
+   */
+  RequestEnricherWaitingQueued = 'REQUEST_ENRICHER_WAITING_QUEUED',
+  /**
+   * - enricher that has an error
+   */
+  RequestEnricherError = 'REQUEST_ENRICHER_ERROR',
+  /**
+   * RequestIdentifier needs to be manually verified
+   */
+  RequestIdentifierNeedsVerification = 'REQUEST_IDENTIFIER_NEEDS_VERIFICATION',
+  /**
+   * - Enrichers of type PERSON that are awaiting manual entry
+   */
+  RequestEnricherPersonNeedsManualEntry = 'REQUEST_ENRICHER_PERSON_NEEDS_MANUAL_ENTRY',
+  /**
+   * - request needs approvals
+   */
+  RequestActionableStatus = 'REQUEST_ACTIONABLE_STATUS',
+  /**
+   * - request is on hold
+   */
+  RequestOnHold = 'REQUEST_ON_HOLD',
+  /**
+   * - A user who hasn't been notified that they've been added to an org.
+   */
+  UserAwaitingNotification = 'USER_AWAITING_NOTIFICATION',
+  /**
+   * - A user created with no scopes or no teams
+   */
+  UserNeedsConfiguration = 'USER_NEEDS_CONFIGURATION',
+  /**
+   * - Old Sombra version upgrade reminder
+   */
+  SombraVersionUpgrade = 'SOMBRA_VERSION_UPGRADE',
+  /**
+   * - Sombra key rotation reminder
+   */
+  SombraNeedsKeyRotation = 'SOMBRA_NEEDS_KEY_ROTATION',
+  /**
+   * - Data Flows that need review
+   */
+  DataFlowNeedsReview = 'DATA_FLOW_NEEDS_REVIEW',
+  /**
+   * - Data Flows that have been assigned for review
+   */
+  DataFlowAssignedForReview = 'DATA_FLOW_ASSIGNED_FOR_REVIEW',
+  /**
+   * - Cookies that need review
+   */
+  CookieNeedsReview = 'COOKIE_NEEDS_REVIEW',
+  /**
+   * - Cookies that have been assigned for review
+   */
+  CookieAssignedForReview = 'COOKIE_ASSIGNED_FOR_REVIEW',
+  /**
+   * - Consent Manager bundle version can be upgraded
+   */
+  ConsentManagerVersionUpgrade = 'CONSENT_MANAGER_VERSION_UPGRADE',
+  /**
+   * - Lookup processes have errored out and are no longer indexing
+   */
+  PluginsWithErrors = 'PLUGINS_WITH_ERRORS',
+  /**
+   * onboarding action item, user-defined with no query handlers
+   */
+  Onboarding = 'ONBOARDING',
+  /**
+   * request that has been assigned to a user
+   */
+  RequestAssignedToUser = 'REQUEST_ASSIGNED_TO_USER',
+  /**
+   * a dataSilo that has less than 80% of discovered sub data points classified
+   */
+  DataSiloNeedsTraining = 'DATA_SILO_NEEDS_TRAINING',
+  /**
+   * business entity needing documentation
+   */
+  BusinessEntityNeedsDocumentation = 'BUSINESS_ENTITY_NEEDS_DOCUMENTATION',
+  /**
+   * A database datapoint has queries that need approval
+   */
+  DataPointDatabaseQueryNeedsApproval = 'DATA_POINT_DATABASE_QUERY_NEEDS_APPROVAL',
+}
+
+/**
+ * Possible values for action item priority override
+ */
+export enum ActionItemPriorityOverride {
+  WontDo = 'WONT_DO',
+  Low = 'LOW',
+  Medium = 'MEDIUM',
+  High = 'HIGH',
+  Critical = 'CRITICAL',
+}

--- a/src/scopes.ts
+++ b/src/scopes.ts
@@ -8,6 +8,7 @@ import { getEntries } from '@transcend-io/type-utils';
 export enum ScopeName {
   ReadOnly = 'readOnly',
   FullAdmin = 'fullAdmin',
+  ViewAllActionItems = 'viewAllActionItems',
   MakeDataSubjectRequest = 'makeDataSubjectRequest',
   ConnectDataSilos = 'connectDataSilos',
   DeployPrivacyCenter = 'deployPrivacyCenter',
@@ -267,6 +268,15 @@ const SCOPES_WITHOUT_VIEW_ONLY: {
     description:
       'View the potential access control scopes that can be assigned to members in the organization.',
     title: 'View Scopes',
+    type: ScopeType.View,
+    products: [TranscendProduct.Admin],
+  },
+  [ScopeName.ViewAllActionItems]: {
+    dependencies: [],
+    description:
+      'View all action items in the organization, regardless of assignee or scopes for specific resources. ' +
+      'This is necessary when querying API keys via the API.',
+    title: 'View All Action Items',
     type: ScopeType.View,
     products: [TranscendProduct.Admin],
   },


### PR DESCRIPTION
This change includes:
- moving `ActionItemCode`  and `ActionItemPriorityOverride` to public repo
- adding new scope to view all action items `viewAllActionItems`

This enables:
- syncing of onboarding related action items using the API by assigning view action item scope to API key
- using the cli to sync in onboarding related action items
- our docs repo can now sync in the list of action item types via the enum
