### PR TITLE
Add PromptStatus so we can deprecate Assessments

### DIFF
--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -45,3 +45,13 @@ export const PROMPT_FILE_PURPOSE_TO_OPEN_AI: {
   [PromptFilePurpose.FineTune]: 'fine-tune',
   [PromptFilePurpose.FineTuneResults]: 'fine-tune-results',
 };
+
+/** Prompt status types */
+export enum PromptStatus {
+  Draft = 'DRAFT',
+  Submitted = 'SUBMITTED',
+  InReview = 'IN_REVIEW',
+  ChangesRequested = 'CHANGES_REQUESTED',
+  Rejected = 'REJECTED',
+  Approved = 'APPROVED',
+}


### PR DESCRIPTION
Prompts currently use `AssessmentStatus`. In order to remove Assessments v1 code, we first need to make a new status enum for prompts.

## Related Issues

- Closes https://transcend.height.app/T-34483

## Security Implications

_[none]_

## System Availability

_[none]_
