### PR TITLE
Add local sync option

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/privacy-types",
   "description": "Core enums and types that can be useful when interacting with Transcend's public APIs.",
-  "version": "4.101.0",
+  "version": "4.102.0",
   "homepage": "https://github.com/transcend-io/privacy-types",
   "repository": {
     "type": "git",

--- a/src/consentManager.ts
+++ b/src/consentManager.ts
@@ -171,7 +171,7 @@ export type BackendSyncOption =
 
 /**
  * Whether or not to run cross-domain sync
- * 
+ *
  * default: 'on'
  */
 export const LocalSyncOption = makeEnum({
@@ -188,4 +188,3 @@ export const LocalSyncOption = makeEnum({
 /** Type override */
 export type LocalSyncOption =
   typeof LocalSyncOption[keyof typeof LocalSyncOption];
-  

--- a/src/consentManager.ts
+++ b/src/consentManager.ts
@@ -168,3 +168,24 @@ export const BackendSyncOption = makeEnum({
 /** Override type */
 export type BackendSyncOption =
   typeof BackendSyncOption[keyof typeof BackendSyncOption];
+
+/**
+ * Whether or not to run cross-domain sync
+ * 
+ * default: 'on'
+ */
+export const LocalSyncOption = makeEnum({
+  /** use private consent sync only */
+  Private: 'private',
+  /** allow network-observable sync when private sync is unavailable */
+  AllowNetworkObservable: 'allow-network-observable',
+  /** comparable to 'allow-network-observable' -- allow network-observable sync when private sync is unavailble */
+  On: 'on',
+  /** disable local sync */
+  Off: 'off',
+});
+
+/** Type override */
+export type LocalSyncOption =
+  typeof LocalSyncOption[keyof typeof LocalSyncOption];
+  

--- a/src/consentManager.ts
+++ b/src/consentManager.ts
@@ -34,7 +34,7 @@ export const DataFlowScope = makeEnum({
 });
 
 /** Type override */
-export type DataFlowScope = (typeof DataFlowScope)[keyof typeof DataFlowScope];
+export type DataFlowScope = typeof DataFlowScope[keyof typeof DataFlowScope];
 
 export const ConsentBundleType = makeEnum({
   /** Bundle hosted at /cm path */
@@ -45,7 +45,7 @@ export const ConsentBundleType = makeEnum({
 
 /** Override type */
 export type ConsentBundleType =
-  (typeof ConsentBundleType)[keyof typeof ConsentBundleType];
+  typeof ConsentBundleType[keyof typeof ConsentBundleType];
 
 export const UnknownRequestPolicy = makeEnum({
   Allow: 'ALLOW',
@@ -55,7 +55,7 @@ export const UnknownRequestPolicy = makeEnum({
 
 /** Override type */
 export type UnknownRequestPolicy =
-  (typeof UnknownRequestPolicy)[keyof typeof UnknownRequestPolicy];
+  typeof UnknownRequestPolicy[keyof typeof UnknownRequestPolicy];
 
 export const TelemetryPartitionStrategy = makeEnum({
   /** Partition telemetry data by the origin (default) */
@@ -68,7 +68,7 @@ export const TelemetryPartitionStrategy = makeEnum({
 
 /** Override type */
 export type TelemetryPartitionStrategy =
-  (typeof TelemetryPartitionStrategy)[keyof typeof TelemetryPartitionStrategy];
+  typeof TelemetryPartitionStrategy[keyof typeof TelemetryPartitionStrategy];
 
 /**
  * The possible options for configuring the Consent resolution precedence
@@ -87,7 +87,7 @@ export const ConsentPrecedenceOption = makeEnum({
 
 /** Override type */
 export type ConsentPrecedenceOption =
-  (typeof ConsentPrecedenceOption)[keyof typeof ConsentPrecedenceOption];
+  typeof ConsentPrecedenceOption[keyof typeof ConsentPrecedenceOption];
 
 /**
  * The possible options for configuring the CSP
@@ -107,7 +107,7 @@ export const CspOption = makeEnum({
 });
 
 /** Override type */
-export type CspOption = (typeof CspOption)[keyof typeof CspOption];
+export type CspOption = typeof CspOption[keyof typeof CspOption];
 
 /**
  * Options for configuring the US Privacy API
@@ -121,7 +121,7 @@ export const UspapiOption = makeEnum({
 });
 
 /** Override type */
-export type UspapiOption = (typeof UspapiOption)[keyof typeof UspapiOption];
+export type UspapiOption = typeof UspapiOption[keyof typeof UspapiOption];
 
 /**
  * Options for configuring the US Privacy API
@@ -138,7 +138,7 @@ export const SignedIabAgreementOption = makeEnum({
 
 /** Override type */
 export type SignedIabAgreementOption =
-  (typeof SignedIabAgreementOption)[keyof typeof SignedIabAgreementOption];
+  typeof SignedIabAgreementOption[keyof typeof SignedIabAgreementOption];
 
 /**
  * Describes whether listed countries/country subdivisions are included in an experience
@@ -152,7 +152,7 @@ export const RegionsOperator = makeEnum({
 
 /** Override type */
 export type RegionsOperator =
-  (typeof RegionsOperator)[keyof typeof RegionsOperator];
+  typeof RegionsOperator[keyof typeof RegionsOperator];
 
 /**
  * Options for configuring Backend Sync
@@ -167,7 +167,7 @@ export const BackendSyncOption = makeEnum({
 
 /** Override type */
 export type BackendSyncOption =
-  (typeof BackendSyncOption)[keyof typeof BackendSyncOption];
+  typeof BackendSyncOption[keyof typeof BackendSyncOption];
 
 /**
  * Whether or not to run local on-device same-site cross-domain sync
@@ -187,4 +187,4 @@ export const LocalSyncOption = makeEnum({
 
 /** Type override */
 export type LocalSyncOption =
-  (typeof LocalSyncOption)[keyof typeof LocalSyncOption];
+  typeof LocalSyncOption[keyof typeof LocalSyncOption];

--- a/src/consentManager.ts
+++ b/src/consentManager.ts
@@ -34,7 +34,7 @@ export const DataFlowScope = makeEnum({
 });
 
 /** Type override */
-export type DataFlowScope = typeof DataFlowScope[keyof typeof DataFlowScope];
+export type DataFlowScope = (typeof DataFlowScope)[keyof typeof DataFlowScope];
 
 export const ConsentBundleType = makeEnum({
   /** Bundle hosted at /cm path */
@@ -45,7 +45,7 @@ export const ConsentBundleType = makeEnum({
 
 /** Override type */
 export type ConsentBundleType =
-  typeof ConsentBundleType[keyof typeof ConsentBundleType];
+  (typeof ConsentBundleType)[keyof typeof ConsentBundleType];
 
 export const UnknownRequestPolicy = makeEnum({
   Allow: 'ALLOW',
@@ -55,7 +55,7 @@ export const UnknownRequestPolicy = makeEnum({
 
 /** Override type */
 export type UnknownRequestPolicy =
-  typeof UnknownRequestPolicy[keyof typeof UnknownRequestPolicy];
+  (typeof UnknownRequestPolicy)[keyof typeof UnknownRequestPolicy];
 
 export const TelemetryPartitionStrategy = makeEnum({
   /** Partition telemetry data by the origin (default) */
@@ -68,7 +68,7 @@ export const TelemetryPartitionStrategy = makeEnum({
 
 /** Override type */
 export type TelemetryPartitionStrategy =
-  typeof TelemetryPartitionStrategy[keyof typeof TelemetryPartitionStrategy];
+  (typeof TelemetryPartitionStrategy)[keyof typeof TelemetryPartitionStrategy];
 
 /**
  * The possible options for configuring the Consent resolution precedence
@@ -87,7 +87,7 @@ export const ConsentPrecedenceOption = makeEnum({
 
 /** Override type */
 export type ConsentPrecedenceOption =
-  typeof ConsentPrecedenceOption[keyof typeof ConsentPrecedenceOption];
+  (typeof ConsentPrecedenceOption)[keyof typeof ConsentPrecedenceOption];
 
 /**
  * The possible options for configuring the CSP
@@ -107,7 +107,7 @@ export const CspOption = makeEnum({
 });
 
 /** Override type */
-export type CspOption = typeof CspOption[keyof typeof CspOption];
+export type CspOption = (typeof CspOption)[keyof typeof CspOption];
 
 /**
  * Options for configuring the US Privacy API
@@ -121,7 +121,7 @@ export const UspapiOption = makeEnum({
 });
 
 /** Override type */
-export type UspapiOption = typeof UspapiOption[keyof typeof UspapiOption];
+export type UspapiOption = (typeof UspapiOption)[keyof typeof UspapiOption];
 
 /**
  * Options for configuring the US Privacy API
@@ -138,7 +138,7 @@ export const SignedIabAgreementOption = makeEnum({
 
 /** Override type */
 export type SignedIabAgreementOption =
-  typeof SignedIabAgreementOption[keyof typeof SignedIabAgreementOption];
+  (typeof SignedIabAgreementOption)[keyof typeof SignedIabAgreementOption];
 
 /**
  * Describes whether listed countries/country subdivisions are included in an experience
@@ -152,7 +152,7 @@ export const RegionsOperator = makeEnum({
 
 /** Override type */
 export type RegionsOperator =
-  typeof RegionsOperator[keyof typeof RegionsOperator];
+  (typeof RegionsOperator)[keyof typeof RegionsOperator];
 
 /**
  * Options for configuring Backend Sync
@@ -167,15 +167,15 @@ export const BackendSyncOption = makeEnum({
 
 /** Override type */
 export type BackendSyncOption =
-  typeof BackendSyncOption[keyof typeof BackendSyncOption];
+  (typeof BackendSyncOption)[keyof typeof BackendSyncOption];
 
 /**
- * Whether or not to run cross-domain sync
+ * Whether or not to run local on-device same-site cross-domain sync
  *
  * default: 'on'
  */
 export const LocalSyncOption = makeEnum({
-  /** use private consent sync only */
+  /** use private sync only */
   Private: 'private',
   /** allow network-observable sync when private sync is unavailable */
   AllowNetworkObservable: 'allow-network-observable',
@@ -187,4 +187,4 @@ export const LocalSyncOption = makeEnum({
 
 /** Type override */
 export type LocalSyncOption =
-  typeof LocalSyncOption[keyof typeof LocalSyncOption];
+  (typeof LocalSyncOption)[keyof typeof LocalSyncOption];


### PR DESCRIPTION
## Related Issues

- links https://transcend.height.app/T-39982 
- Adds type of localSync (Controls whether or not to run cross-domain sync). Will be added as a loadOption users can update in AD. Corresponds to this setting: https://github.com/transcend-io/main/blob/fcbc6aff9c142dbea743cec8281b47d29accac03/frontend-support/ag-types/src/core.ts#L724

## Security Implications

_[none]_

## System Availability

_[none]_
