### PR TITLE
update OneTrustAssessmentCsvRecord to be a map to string only

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/privacy-types",
   "description": "Core enums and types that can be useful when interacting with Transcend's public APIs.",
-  "version": "4.105.0",
+  "version": "4.105.1",
   "homepage": "https://github.com/transcend-io/privacy-types",
   "repository": {
     "type": "git",

--- a/src/oneTrust/oneTrustAssessmentCsv.ts
+++ b/src/oneTrust/oneTrustAssessmentCsv.ts
@@ -675,7 +675,7 @@ export const OneTrustAssessmentCsvRecord = t.record(
       null,
   }),
   /** The values of the header */
-  t.union([t.string, t.number]),
+  t.string,
 );
 
 /**


### PR DESCRIPTION
- the OneTrust CSV file is composed of strings only, not numbers!

## Related Issues

- _[none]_

## Security Implications

_[none]_

## System Availability

_[none]_
