### PR TITLE
bump version to 4.105.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/privacy-types",
   "description": "Core enums and types that can be useful when interacting with Transcend's public APIs.",
-  "version": "4.105.4",
+  "version": "4.105.5",
   "homepage": "https://github.com/transcend-io/privacy-types",
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Before I merged my [4.105.4 changes](https://github.com/transcend-io/privacy-types/pull/209/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R5) another PR [with the same version](https://github.com/transcend-io/privacy-types/pull/211/files) also got merged. Hence, 4.105.4 changes did not get deployed.