### PR TITLE
Add scannedObjects + scannedObjectPaths to AttributeSupportedResourceType

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/privacy-types",
   "description": "Core enums and types that can be useful when interacting with Transcend's public APIs.",
-  "version": "4.105.8",
+  "version": "4.105.9",
   "homepage": "https://github.com/transcend-io/privacy-types",
   "repository": {
     "type": "git",

--- a/src/attribute.ts
+++ b/src/attribute.ts
@@ -46,6 +46,10 @@ export enum AttributeSupportedResourceType {
   PromptRun = 'promptRun',
   /** Requests table */
   Request = 'request',
+  /** ScannedObject table */
+  ScannedObject = 'scannedObject',
+  /** ScannedObjectPath table */
+  ScannedObjectPath = 'scannedObjectPath',
   /** Subject table */
   Subject = 'subject',
   /** Subdatapoints table (shows up under Data Inventory > Data Points tab) */


### PR DESCRIPTION
Adds scannedObjects + scannedObjectPaths to AttributeSupportedResourceType so they can be used in the AD.

## Related Issues

- https://transcend-inc.slack.com/archives/C0605QB7QD7/p1740150879195679
