### PR TITLE
Add identifiers to types

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/privacy-types",
   "description": "Core enums and types that can be useful when interacting with Transcend's public APIs.",
-  "version": "4.107.0",
+  "version": "4.108.0",
   "homepage": "https://github.com/transcend-io/privacy-types",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/privacy-types",
   "description": "Core enums and types that can be useful when interacting with Transcend's public APIs.",
-  "version": "4.108.0",
+  "version": "4.109.0",
   "homepage": "https://github.com/transcend-io/privacy-types",
   "repository": {
     "type": "git",

--- a/src/preferences.ts
+++ b/src/preferences.ts
@@ -134,7 +134,7 @@ export const PreferenceQueryResponseItem = t.intersection([
     identifiers: t.array(PreferenceStoreIdentifier),
   }),
   t.partial({
-    /** Primary identifier of the user.*/
+    /** Primary identifier of the user. */
     userId: t.string,
     /** metadata */
     metadata: t.array(
@@ -207,7 +207,7 @@ export const PreferenceUpdateItem = t.intersection([
   t.partial({
     /** Primary identifier of the user.*/
     userId: t.string,
-   /** Identifiers associated to the user */
+    /** Identifiers associated to the user */
     identifiers: t.array(PreferenceStoreIdentifier),
     /** Preference store purposes */
     purposes: t.array(PreferenceStorePurposeUpdate),

--- a/src/preferences.ts
+++ b/src/preferences.ts
@@ -17,7 +17,7 @@ export type DecryptionStatus =
  * Preference store identifier
  */
 export const PreferenceStoreIdentifier = t.type({
-  /** The identifier name */
+  /** The identifier name (email, phone etc) */
   name: t.string,
   /** The identifier value */
   value: t.string,

--- a/src/preferences.ts
+++ b/src/preferences.ts
@@ -124,7 +124,15 @@ export const PreferenceQueryResponseItem = t.intersection([
     consentManagement: t.partial(PreferenceStoreConsentFields.props),
     /** Preference store purposes */
     purposes: t.array(PreferenceStorePurposeResponse),
-  }),
+    /** Identifiers associated to the user */
+    identifiers:  t.array(
+      t.type({
+        /** The identifier name */
+        name: t.string,
+        /** The identifier value */
+        value: t.string,
+      }),
+    ),
   t.partial({
     /** metadata */
     metadata: t.array(

--- a/src/preferences.ts
+++ b/src/preferences.ts
@@ -130,12 +130,12 @@ export const PreferenceQueryResponseItem = t.intersection([
     consentManagement: t.partial(PreferenceStoreConsentFields.props),
     /** Preference store purposes */
     purposes: t.array(PreferenceStorePurposeResponse),
-    /** Identifiers associated to the user */
-    identifiers: t.array(PreferenceStoreIdentifier),
   }),
   t.partial({
     /** Primary identifier of the user. */
     userId: t.string,
+    /** Identifiers associated to the user */
+    identifiers: t.array(PreferenceStoreIdentifier),
     /** metadata */
     metadata: t.array(
       t.type({

--- a/src/preferences.ts
+++ b/src/preferences.ts
@@ -14,6 +14,21 @@ export type DecryptionStatus =
   typeof DecryptionStatus[keyof typeof DecryptionStatus];
 
 /**
+ * Preference store identifier
+ */
+export const PreferenceStoreIdentifier = t.type({
+  /** The identifier name */
+  name: t.string,
+  /** The identifier value */
+  value: t.string,
+});
+
+/** Override type */
+export type PreferenceStoreIdentifier = t.TypeOf<
+  typeof PreferenceStoreIdentifier
+>;
+
+/**
  * Preference store system attributes which are not user editable
  */
 export const PreferenceStoreSystemAttributes = t.intersection([
@@ -56,15 +71,6 @@ export type PreferenceStoreConsentFields = t.TypeOf<
  * The format key required fields of the preference store record
  */
 export const PreferenceStoreKeyConditionals = t.type({
-  /**
-   * Primary identifier of the user.
-   *
-   * - **Lookup**: This value may be encrypted or decrypted, depending on the decryption status.
-   * - **Upsert**: This value is always provided in decrypted form by the API user.
-   *
-   * Ensure to handle the user ID appropriately based on the context of the operation.
-   */
-  userId: t.string,
   /** The partition key */
   partition: t.string,
   /** last consent event timestamp (ISO 8601) */
@@ -125,16 +131,11 @@ export const PreferenceQueryResponseItem = t.intersection([
     /** Preference store purposes */
     purposes: t.array(PreferenceStorePurposeResponse),
     /** Identifiers associated to the user */
-    identifiers: t.array(
-      t.type({
-        /** The identifier name */
-        name: t.string,
-        /** The identifier value */
-        value: t.string,
-      }),
-    ),
+    identifiers: t.array(PreferenceStoreIdentifier),
   }),
   t.partial({
+    /** Primary identifier of the user.*/
+    userId: t.string,
     /** metadata */
     metadata: t.array(
       t.type({
@@ -204,6 +205,10 @@ export type PreferenceStorePurposeUpdate = t.TypeOf<
 export const PreferenceUpdateItem = t.intersection([
   PreferenceStoreKeyConditionals,
   t.partial({
+    /** Primary identifier of the user.*/
+    userId: t.string,
+   /** Identifiers associated to the user */
+    identifiers: t.array(PreferenceStoreIdentifier),
     /** Preference store purposes */
     purposes: t.array(PreferenceStorePurposeUpdate),
     /** Consent management related fields */

--- a/src/preferences.ts
+++ b/src/preferences.ts
@@ -205,7 +205,7 @@ export type PreferenceStorePurposeUpdate = t.TypeOf<
 export const PreferenceUpdateItem = t.intersection([
   PreferenceStoreKeyConditionals,
   t.partial({
-    /** Primary identifier of the user.*/
+    /** Primary identifier of the user. */
     userId: t.string,
     /** Identifiers associated to the user */
     identifiers: t.array(PreferenceStoreIdentifier),

--- a/src/preferences.ts
+++ b/src/preferences.ts
@@ -125,7 +125,7 @@ export const PreferenceQueryResponseItem = t.intersection([
     /** Preference store purposes */
     purposes: t.array(PreferenceStorePurposeResponse),
     /** Identifiers associated to the user */
-    identifiers:  t.array(
+    identifiers: t.array(
       t.type({
         /** The identifier name */
         name: t.string,
@@ -133,6 +133,7 @@ export const PreferenceQueryResponseItem = t.intersection([
         value: t.string,
       }),
     ),
+  }),
   t.partial({
     /** metadata */
     metadata: t.array(


### PR DESCRIPTION
## Related Issues

- links [T-40236](https://transcend.height.app/T-40236)

## Internal Change log

- Add identifiers to `PreferenceUpdateItem`, `PreferenceQueryResponseItem`.
- Makes `userId` optional.
- Defines `PreferenceStoreIdentifier`.
