### PR TITLE
add OneTrustQuestionComment to oneTrust types

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/privacy-types",
   "description": "Core enums and types that can be useful when interacting with Transcend's public APIs.",
-  "version": "4.110.0",
+  "version": "4.110.1",
   "homepage": "https://github.com/transcend-io/privacy-types",
   "repository": {
     "type": "git",

--- a/src/oneTrust/enrichedCodecs.ts
+++ b/src/oneTrust/enrichedCodecs.ts
@@ -35,10 +35,16 @@ export const OneTrustQuestionComment = t.type({
   CreateDate: t.string,
 });
 
+/**
+ *
+ */
 export type OneTrustQuestionComment = t.TypeOf<typeof OneTrustQuestionComment>;
 
 export const OneTrustQuestionComments = t.array(OneTrustQuestionComment);
 
+/**
+ *
+ */
 export type OneTrustQuestionComments = t.TypeOf<
   typeof OneTrustQuestionComments
 >;

--- a/src/oneTrust/enrichedCodecs.ts
+++ b/src/oneTrust/enrichedCodecs.ts
@@ -39,7 +39,9 @@ export type OneTrustQuestionComment = t.TypeOf<typeof OneTrustQuestionComment>;
 
 export const OneTrustQuestionComments = t.array(OneTrustQuestionComment);
 
-export type OneTrustQuestionComments = t.TypeOf<typeof OneTrustQuestionComments>;
+export type OneTrustQuestionComments = t.TypeOf<
+  typeof OneTrustQuestionComments
+>;
 
 /** The default OneTrust Get Assessment question response with enriched risks. */
 export const OneTrustEnrichedAssessmentQuestion = t.intersection([

--- a/src/oneTrust/enrichedCodecs.ts
+++ b/src/oneTrust/enrichedCodecs.ts
@@ -36,14 +36,14 @@ export const OneTrustQuestionComment = t.type({
 });
 
 /**
- *
+ * A OneTrust comment manually injected to the question
  */
 export type OneTrustQuestionComment = t.TypeOf<typeof OneTrustQuestionComment>;
 
 export const OneTrustQuestionComments = t.array(OneTrustQuestionComment);
 
 /**
- *
+ * A list of OneTrust comment manually injected to the question
  */
 export type OneTrustQuestionComments = t.TypeOf<
   typeof OneTrustQuestionComments

--- a/src/oneTrust/enrichedCodecs.ts
+++ b/src/oneTrust/enrichedCodecs.ts
@@ -29,13 +29,28 @@ export const OneTrustEnrichedRisks = t.union([
 /** Type override */
 export type OneTrustEnrichedRisks = t.TypeOf<typeof OneTrustEnrichedRisks>;
 
+export const OneTrustQuestionComment = t.type({
+  comment: t.string,
+  CreatedBy: t.string,
+  CreateDate: t.string,
+});
+
+export type OneTrustQuestionComment = t.TypeOf<typeof OneTrustQuestionComment>;
+
+export const OneTrustQuestionComments = t.array(OneTrustQuestionComment);
+
+export type OneTrustQuestionComments = t.TypeOf<typeof OneTrustQuestionComments>;
+
 /** The default OneTrust Get Assessment question response with enriched risks. */
 export const OneTrustEnrichedAssessmentQuestion = t.intersection([
   t.type({
     ...OneTrustAssessmentQuestion.types[0].props,
     risks: OneTrustEnrichedRisks,
   }),
-  t.partial({ ...OneTrustAssessmentQuestion.types[1].props }),
+  t.partial({
+    ...OneTrustAssessmentQuestion.types[1].props,
+    comments: OneTrustQuestionComments,
+  }),
 ]);
 
 /** Type override */


### PR DESCRIPTION
## Related Issues

- closes https://transcend.height.app/T-43651

## Description

- We need this to support importing assessment question comments from OneTrust. This is part of a minor patch I'm writing to fulfill an Informa request.