### PR TITLE
Update Tax Category Name to Tax Information

### DIFF
--- a/src/subcategories/financial.ts
+++ b/src/subcategories/financial.ts
@@ -9,7 +9,7 @@ export const FinancialSubCategory = makeEnum({
   /** Income */
   Income: 'INCOME',
   /** Tax information */
-  Tax: 'TAX',
+  TaxInformation: 'TAX_INFORMATION',
   /** Routing number */
   RoutingNumber: 'ROUTING_NUMBER',
   /** Fallback subcategory */


### PR DESCRIPTION
## Related Issues

- Links https://transcend.height.app/T-42382

- we save result of tax category as TAX_INFORMATION, so we should keep name the same to avoid making mistaked during result comparison
