### PR TITLE
Add timestamp to PreferenceStorePurposeUpdate

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/privacy-types",
   "description": "Core enums and types that can be useful when interacting with Transcend's public APIs.",
-  "version": "4.111.0",
+  "version": "4.112.0",
   "homepage": "https://github.com/transcend-io/privacy-types",
   "repository": {
     "type": "git",

--- a/src/preferences.ts
+++ b/src/preferences.ts
@@ -169,7 +169,7 @@ export type CustomFieldApiInput = t.TypeOf<typeof CustomFieldApiInput>;
 export const PreferenceStorePurposeUpdate = t.intersection([
   PreferenceStorePurposeResponse,
   t.partial({
-    /** Timestamp of the purpose was last updated (ISO 8601) */
+    /** Timestamp of when the purpose was last updated (ISO 8601) */
     timestamp: t.string,
     /** Additional tags to forward to the DSR event */
     attributes: t.array(CustomFieldApiInput),

--- a/src/preferences.ts
+++ b/src/preferences.ts
@@ -169,6 +169,8 @@ export type CustomFieldApiInput = t.TypeOf<typeof CustomFieldApiInput>;
 export const PreferenceStorePurposeUpdate = t.intersection([
   PreferenceStorePurposeResponse,
   t.partial({
+    /** Timestamp of the purpose was last updated (ISO 8601) */
+    timestamp: t.string,
     /** Additional tags to forward to the DSR event */
     attributes: t.array(CustomFieldApiInput),
     /** Consent workflow settings */


### PR DESCRIPTION
## Related Issues

- links [T-44475](https://transcend.height.app/T-44475)

## Related Change log

- Adds optinal timestamp field on update purpose input.
