### PR TITLE
[KIR-16212] Add metadata to SubDataPointAttribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/privacy-types",
   "description": "Core enums and types that can be useful when interacting with Transcend's public APIs.",
-  "version": "4.128.0",
+  "version": "4.129.0",
   "homepage": "https://github.com/transcend-io/privacy-types",
   "repository": {
     "type": "git",

--- a/src/assessmentQuestion.ts
+++ b/src/assessmentQuestion.ts
@@ -211,7 +211,8 @@ type SubDataPointAttributeImmutable =
   | 'DELETED_AT'
   | 'DATA_TYPE'
   | 'ENCRYPTION'
-  | 'IS_PRIMARY_KEY';
+  | 'IS_PRIMARY_KEY'
+  | 'METADATA';
 
 /**
  * The attributes of the SubDataPoint model.
@@ -239,6 +240,7 @@ export const SubDataPointAttribute = makeEnum({
   DataType: 'dataType',
   Encryption: 'encryption',
   IsPrimaryKey: 'isPrimaryKey',
+  Metadata: 'metadata',
 });
 
 /** Type override */
@@ -272,6 +274,7 @@ export const SubDataPointAttributeSyncColumn = makeEnum<
   dataType: 'DATA_TYPE',
   encryption: 'ENCRYPTION',
   isPrimaryKey: 'IS_PRIMARY_KEY',
+  metadata: 'METADATA',
 });
 
 /** Type override */
@@ -675,6 +678,7 @@ export const AssessmentSyncColumn = makeEnum<
     'DATA_PROTECTION_IMPACT_ASSESSMENT_LINK',
   DATA_PROTECTION_IMPACT_ASSESSMENT_STATUS:
     'DATA_PROTECTION_IMPACT_ASSESSMENT_STATUS',
+  METADATA: 'METADATA',
 });
 
 /** Type override */


### PR DESCRIPTION
## Related Issues

- [KIR-16212](https://linear.app/transcend/issue/KIR-16212/update-datapoint-schema-discovery-for-salesforce-to-pull-in-field)

To resolve error
```
Error: backend-support/datamap-models/src/subDataPoint/definition.ts(223,3): error TS2353: Object literal may only specify known properties, and 'metadata' does not exist in type '{ dataPointId: Attribute; description: Attribute; deletedAt: Attribute; retentionType: Attribute; retentionPeriod: Attribute; ... 16 more ...; isPrimaryKey: Attribute; }'.
```
from this [PR](https://github.com/transcend-io/main/pull/35766).