### PR TITLE
Add `region` to preferences API

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/privacy-types",
   "description": "Core enums and types that can be useful when interacting with Transcend's public APIs.",
-  "version": "4.131.0",
+  "version": "4.132.0",
   "homepage": "https://github.com/transcend-io/privacy-types",
   "repository": {
     "type": "git",

--- a/src/preferences.ts
+++ b/src/preferences.ts
@@ -1,5 +1,6 @@
 import * as t from 'io-ts';
 import { makeEnum, valuesOf } from '@transcend-io/type-utils';
+import { IsoCountryCode, IsoCountrySubdivisionCode } from './isoRegion';
 
 /**
  * Types of decryption status
@@ -228,6 +229,13 @@ export const PreferenceUpdateItem = t.intersection([
      * TODO: https://transcend.height.app/T-40208 - move this to `PreferenceStoreKeyConditionals` when stored on record
      */
     locale: t.string, // Should be LanguageKey but omitting to allow for sombra to update independently
+    /** Country and/or country subdivision, to pass along to DSR request */
+    region: t.partial({
+      /** The country ISO code */
+      country: IsoCountryCode,
+      /** The country subdivision ISO code */
+      countrySubDivision: IsoCountrySubdivisionCode,
+    }),
     /** The metadata associated with the record */
     metadata: t.array(
       t.type({

--- a/src/preferences.ts
+++ b/src/preferences.ts
@@ -232,9 +232,9 @@ export const PreferenceUpdateItem = t.intersection([
     /** Country and/or country subdivision, to pass along to DSR request */
     region: t.partial({
       /** The country ISO code */
-      country: IsoCountryCode,
+      country: valuesOf(IsoCountryCode),
       /** The country subdivision ISO code */
-      countrySubDivision: IsoCountrySubdivisionCode,
+      countrySubDivision: valuesOf(IsoCountrySubdivisionCode),
     }),
     /** The metadata associated with the record */
     metadata: t.array(


### PR DESCRIPTION
## Related Issues

- links https://linear.app/transcend/issue/WAR-3393/expose-region-in-api#comment-bc61fd08
- links https://linear.app/transcend/issue/WAR-5356/add-region-as-request-body-param-for-put-preferences-api

To support Costco for [/v1/preferences](https://docs.transcend.io/docs/api-reference/PUT/v1/preferences#request-body) API. 
Mimics `region` in [/v1/data-subject-request](https://docs.transcend.io/docs/api-reference/POST/v1/data-subject-request#request-body) API

Slack https://transcend-inc.slack.com/archives/C08EVK68WEQ/p1758155383041579?thread_ts=1758150705.507769&cid=C08EVK68WEQ
