### PR TITLE
[LINK-5390]: Update AssessmentQuestionSubType enum in privacy-types to have new Sensitive Categories sub type option

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/privacy-types",
   "description": "Core enums and types that can be useful when interacting with Transcend's public APIs.",
-  "version": "4.145.0",
+  "version": "4.146.0",
   "homepage": "https://github.com/transcend-io/privacy-types",
   "repository": {
     "type": "git",

--- a/src/assessmentForm.ts
+++ b/src/assessmentForm.ts
@@ -120,6 +120,8 @@ export const AssessmentQuestionSubType = makeEnum({
   HasPersonalData: 'HAS_PERSONAL_DATA',
   /** The Attribute Key referring to a custom field */
   AttributeKey: 'ATTRIBUTE_KEY',
+  /** A sensitive category */
+  SensitiveCategory: 'SENSITIVE_CATEGORY',
 });
 
 /**


### PR DESCRIPTION
## Description
Need to add Sensitive Categories sub type option in `AssessmentQuestionSubType` enum in privacy-types to support sensitive categories in assessment module.

## Related Issues

- Closes https://linear.app/transcend/issue/LINK-5390/privacy-types-update-assessmentquestionsubtype-enum-in-privacy-types

## Changes

- Updated `AssessmentQuestionSubType` to include option for sensitive categories